### PR TITLE
Removes taco-tile.png to ensure a clean ui

### DIFF
--- a/src/widgets/Menu/Menu.tsx
+++ b/src/widgets/Menu/Menu.tsx
@@ -44,7 +44,6 @@ const Inner = styled.div<{ isPushed: boolean; showMenu: boolean }>`
   margin-top: ${({ showMenu }) => (showMenu ? `${MENU_HEIGHT}px` : 0)};
   transition: margin-top 0.2s;
   transform: translate3d(0, 0, 0);
-  background: url(/taco-tile.png);
   ${({ theme }) => theme.mediaQueries.nav} {
     margin-left: ${({ isPushed }) => `${isPushed ? SIDEBAR_WIDTH_FULL : SIDEBAR_WIDTH_REDUCED}px`};
   }


### PR DESCRIPTION
I don't know what you guys think, but I think the ui looks way cleaner without the taco tiles. Feel free to merge this pull request if you like it :)

![Screenshot 2021-03-02 at 11 35 20](https://user-images.githubusercontent.com/79135493/109636053-68720a80-7b4b-11eb-9e6f-1ba83de974ad.png)

